### PR TITLE
feat(reporting): integrate reporting workflow into CLI and orchestrators

### DIFF
--- a/run_scan.py
+++ b/run_scan.py
@@ -16,6 +16,8 @@ from crawler import crawl
 from payloads import get_payloads
 from fuzzer import generate_tests_from_params, generate_tests_from_forms, submit_test_case
 from scanner import Scanner
+from reporter import save_report
+
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskProgressColumn
 
@@ -392,6 +394,16 @@ class EthioScanOrchestrator:
             # Save results
             self.save_findings(findings)
             self.create_summary(findings)
+
+            # Generate final report
+            meta = {
+                        "target": self.args.url,
+                        "depth": self.args.depth,
+                        "concurrency": self.args.concurrency,
+                        "report_format": self.args.report,
+                    }
+            save_report(meta, findings, self.args.report, self.args.out, tests_run=len(findings))
+            console.print(f"[green]Detailed report saved to {self.args.out}[/green]")
             
             # Print final summary
             elapsed = time.time() - start_time

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -10,20 +10,39 @@
     th, td { border:1px solid #ddd; padding:8px; vertical-align: top; }
     th { background:#f5f5f5; text-align:left; }
     code { background:#f6f8fa; padding:2px 4px; border-radius:4px; }
+    .sev-critical { color:red; font-weight:bold; }
+    .sev-high { color:darkred; font-weight:bold; }
+    .sev-medium { color:orange; font-weight:bold; }
+    .sev-low { color:blue; font-weight:bold; }
+    .sev-unknown { color:gray; }
   </style>
 </head>
 <body>
   <h1>EthioScan Report</h1>
   <p>
-    Target: <strong>{{ meta.target }}</strong> • Generated: {{ meta.generated_at }}
-    • Depth: {{ meta.depth }} • Tests run: {{ meta.tests_run }}
+    Target: <strong>{{ meta.target }}</strong><br>
+    Generated: {{ meta.generated_at }}<br>
+    Depth: {{ meta.depth }} • Concurrency: {{ meta.concurrency }}<br>
+    Tests run: {{ meta.tests_run }} • Format: {{ meta.report_format }}
   </p>
 
   <h2>Summary</h2>
   <ul>
     <li>Total Findings: <strong>{{ summary.total }}</strong></li>
-    <li>By Severity: {{ summary.by_severity }}</li>
-    <li>By Category: {{ summary.by_category }}</li>
+    <li>By Severity:
+      <ul>
+        {% for sev, count in summary.by_severity.items() %}
+          <li>{{ sev | capitalize }}: {{ count }}</li>
+        {% endfor %}
+      </ul>
+    </li>
+    <li>By Category:
+      <ul>
+        {% for cat, count in summary.by_category.items() %}
+          <li>{{ cat | capitalize }}: {{ count }}</li>
+        {% endfor %}
+      </ul>
+    </li>
   </ul>
 
   <h2>Findings</h2>
@@ -36,11 +55,19 @@
         {% for f in findings %}
         <tr>
           <td>{{ f.category }}</td>
-          <td>{{ f.severity }}</td>
+          <td class="sev-{{ f.severity | default('unknown') | lower }}">{{ f.severity | capitalize }}</td>
           <td><code>{{ f.url or f.final_url }}</code></td>
           <td>{{ f.param }}</td>
-          <td><code>{{ f.payload }}</code></td>
-          <td><pre style="white-space:pre-wrap">{{ f.evidence }}</pre></td>
+          <td><code>
+            {% if f.payload is string %}
+              {{ f.payload }}
+            {% elif f.payload is mapping %}
+              {{ f.payload.payload }}
+            {% else %}
+              {{ f.payload | string }}
+            {% endif %}
+          </code></td>
+          <td><pre style="white-space:pre-wrap">{{ f.evidence | default("") }}</pre></td>
         </tr>
         {% endfor %}
       {% else %}

--- a/utils.py
+++ b/utils.py
@@ -10,7 +10,8 @@ from crawler import crawl, crawl_sync
 from fuzzer import generate_tests_from_params, generate_tests_from_forms, submit_test_case, get_test_case_summary
 from scanner import Scanner
 from payloads import get_payloads
-# from reporter import save_report  # you'll implement this next
+from reporter import save_report
+
 
 console = Console()
 
@@ -69,10 +70,19 @@ def run_scan(args):
         asyncio.run(run_tests())
         
         console.print(f"[red]Detected {len(findings)} findings[/red]")
+
         
-        # Step 4: Reporting (to implement)
-        # save_report(findings, args.report, args.out)
-        console.print("[yellow]Reporting still needs to be implemented[/yellow]")
+        # Step 4: Reporting
+        meta = {
+            "target": args.url,
+            "depth": args.depth,
+            "concurrency": args.concurrency,
+            "report_format": args.report,
+                }
+        save_report(meta, findings, args.report, args.out, tests_run=len(findings))
+        console.print(f"[green]Report generated at {args.out}[/green]")
+
+
         
     except Exception as e:
         console.print(f"[red]Error during scanning: {e}[/red]")


### PR DESCRIPTION
- Added Jinja2-based HTML report template (templates/report_template.html)
- Integrated report generation step into run_scan.py and utils.py
- Updated cli.py to pass report options and ensure reporting works end-to-end
- Improved orchestrator to save findings, create summaries, and generate reports
- Enhanced output with severity highlighting and structured summaries

This commit connects the full pipeline (crawl → fuzz → scan → report) with initial reporting support, making EthioScan produce useful HTML/JSON reports.